### PR TITLE
Updated interim URL for link to VUC on bottom of Landing Page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,6 +5,6 @@ links:
   - title: Document Library
     collection: document-library
   - title: Virtual Union Catalogue
-    url: https://www.vuc.sg/
+    url: https://www.nlb.gov.sg/main/services/For-Publishers/Virtual-Union-Catalogue
   - title: Contact Us
     url: /contact-us/

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: National Library Board
 description: test test
 image: /images/isomer-logo.svg
 permalink: /
-notification: null
+notification: ""
 sections:
   - hero:
       title: SILAS


### PR DESCRIPTION
The interim re-direct to VUC URL provided by TSG Michael Ong (while Spydus VUC is being retired/taken down on 31 Jan 2024).